### PR TITLE
Options to loadout

### DIFF
--- a/missionConfig/configEquipment/functions/fn_configEquipment_blu_f.sqf
+++ b/missionConfig/configEquipment/functions/fn_configEquipment_blu_f.sqf
@@ -55,7 +55,7 @@
 // Variable declarations.                                                                                //
 //=======================================================================================================//
 
-private["_isInfantry"];
+private["_isInfantry", "_unitRole"];
 private["_uniform", "_vestSL", "_vestTL", "_vestRFL", "_vestGR", "_vestME", "_vestSAW", "_vestDIV", "_helmet", "_helmetSN", "_helmetCRW", "_backpack", "_uavBackpack", "_unitInsignia"];
 private["_uavBattery", "_cableTie", "_mapTools", "_microDAGR", "_earPlugs", "_vectorIV", "_atragmx", "_kestrel", "_clacker", "_clackerm26", "_defusalKit", "_cellphone"];
 private["_atropine", "_epinephrine", "_morphine", "_bandage", "_elasticBandage", "_quickClot", "_packingBandage"];
@@ -67,7 +67,13 @@ private["_flashlight"];
 // Get unit role and if it is an infantry unit.                                                          //
 //=======================================================================================================//
 
-params ["_unitRole", "_unit", "_unitFaction"];
+params ["_unitOptions", "_unit", "_unitFaction"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 _unitRole = toLower _unitRole;
 

--- a/missionConfig/configEquipment/functions/fn_configEquipment_bwa3_faction.sqf
+++ b/missionConfig/configEquipment/functions/fn_configEquipment_bwa3_faction.sqf
@@ -22,7 +22,7 @@
 //=======================================================================================================//
 // Variable declarations.                                                                                //
 //=======================================================================================================//
-private["_isInfantry"];
+private["_isInfantry", "_unitRole"];
 private["_uniform", "_vestLD", "_vestRFL", "_vestGR", "_vestDM", "_vestME", "_vestAR", "_helmet", "_helmetSN", "_backpack", "uavBackpack", "_unitInsignia"];
 private["_uavBattery", "_cableTie", "_mapTools", "_microDAGR", "_earPlugs", "_vectorIV", "_atragmx", "_kestrel", "_clacker", "_clackerm26", "_defusalKit", "_cellphone"];
 private["_atropine", "_epinephrine", "_morphine", "_bandage", "_elasticBandage", "_quickClot", "_packingBandage"];
@@ -33,7 +33,14 @@ private["_personalAidKid", "_surgicalKit", "_tourniquet"];
 // Get unit role and if it is an infantry unit.                                                          //
 //=======================================================================================================//
 
-params ["_unitRole", "_unit", "_unitFaction"];
+params ["_unitOptions", "_unit", "_unitFaction"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
+
 _unitRole = toLower _unitRole;
 
 if ( isNil "_unitFaction") then {

--- a/missionConfig/configEquipment/functions/fn_configEquipment_rhs_usaf.sqf
+++ b/missionConfig/configEquipment/functions/fn_configEquipment_rhs_usaf.sqf
@@ -57,7 +57,7 @@
 //=======================================================================================================//
 // Variable declarations.                                                                                //
 //=======================================================================================================//
-private["_isInfantry"];
+private["_isInfantry", "_unitRole"];
 private["_uniform", "_vestSL", "_vestTL", "_vestRFL", "_vestGR", "_vestDM", "_vestME", "_vestAR", "_vestMG", "_vestCRW", "_helmet", "_helmetSN", "_helmetCRW", "_backpack", "_uavBackpack", "_unitInsignia"];
 private["_uavBattery", "_cableTie", "_mapTools", "_microDAGR", "_earPlugs", "_vectorIV", "_atragmx", "_kestrel", "_clacker", "_clackerm26", "_defusalKit", "_cellphone"];
 private["_atropine", "_epinephrine", "_morphine", "_bandage", "_elasticBandage", "_quickClot", "_packingBandage"];
@@ -69,7 +69,14 @@ private["_flashlight"];
 // Get unit role and if it is an infantry unit.                                                          //
 //=======================================================================================================//
 
-params ["_unitRole", "_unit", "_unitFaction"];
+params ["_unitOptions", "_unit", "_unitFaction"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
+
 _unitRole = toLower _unitRole;
 
 if ( isNil "_unitFaction") then {

--- a/src/acre2/functions/fn_acre2_addRadios.sqf
+++ b/src/acre2/functions/fn_acre2_addRadios.sqf
@@ -13,9 +13,15 @@
 
 // Variable declarations.
 params [["_unit", objNull]];
-private["_unit", "_unitRole"];
+private["_unit", "_unitOptions", "_unitRole"];
 
-_unitRole = _unit getVariable ["bmt_var_configEquipment", "nil"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "nil"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 // Assign radios depending on the unit role (fn_configEquipment).
 if (!isNil "_unitRole") then {

--- a/src/acre2/functions/fn_acre2_configureChannels.sqf
+++ b/src/acre2/functions/fn_acre2_configureChannels.sqf
@@ -13,13 +13,19 @@
 
 // Variable declarations.
 params [["_unit", objNull]];
-private ["_unitGroup", "_unitRole", "_channel", "_squadChannel", "_fireteamChannel", "_commandChannel"];
+private ["_unitGroup", "_unitOptions", "_unitRole", "_channel", "_squadChannel", "_fireteamChannel", "_commandChannel"];
 private ["_radioList"];
 
 sleep 3;
 
 _unitGroup = _unit getVariable ["bmt_var_unitGroup", ["nil", -1]];
-_unitRole = _unit getVariable ["bmt_var_configEquipment", "NIL"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "NIL"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 if ((_unitGroup select 0 == "nil") or (_unitGroup select 1 == -1)) exitWith {
     _unit sideChat format ["ERROR (fn_acre2_configureChannels.sqf): Channels cannot be configured since variable ""bmt_var_unitGroup"" is not correctly defined: [%1,%2].", _unitGroup select 0, _unitGroup select 1];

--- a/src/configEquipment/functions/fn_configEquipment.sqf
+++ b/src/configEquipment/functions/fn_configEquipment.sqf
@@ -6,12 +6,14 @@
 // Description: This function equips the unit according to a specified role and depending on the faction //
 //              it belongs to.                                                                           //
 //              Arguments:                                                                               //
-//               - 0: unit role <STRING>.                                                                //
+//               - 0: unit role <STRING> or array of strings with the first element beign the unit role. //
 //               - 1: unit <OBJECT>.                                                                     //
 //               - 2: unit faction <STRING><OPTIONAL>.                                                   //
 //              Examples:                                                                                //
 //               - Unit is a Fire Team Leader.                                                           //
 //                   ["tl", this] call bmt_fnc_configEquipment;                                          //
+//               - Unit is a Squad Leader with optional equipment foo.                                   //
+//                   [["sl", "foo"], this] call bmt_fnc_configEquipment;                                 //
 //               - Unit is a medic and has the equipment of the RHS faction "United States Marine Corps" //
 //                 (D) despite not belonging to it.                                                      //
 //                   ["me", this, "rhs_faction_usmc_d"] call bmt_fnc_configEquipment;                    //
@@ -78,7 +80,7 @@
 //=======================================================================================================//
 
 // Variable declaration.
-params ["_unitRole", "_unit", ["_unitFaction", nil]];
+params ["_unitOptions", "_unit", ["_unitFaction", nil]];
 private ["_recognised"];
 
 // Only execute if unit is local.
@@ -87,9 +89,6 @@ if !(local _unit) exitWith {};
 // Assume faction is recognised.
 _recognised = true;
 
-// Set unit type to lower case.
-_unitRole = toLower _unitRole;
-
 if (isNil "_unitFaction") then {
     _unitFaction = toLower (faction _unit);
 } else {
@@ -97,7 +96,7 @@ if (isNil "_unitFaction") then {
 };
 
 // Save unit type.
-_unit setVariable ["bmt_var_configEquipment", _unitRole, true];
+_unit setVariable ["bmt_var_configEquipment", _unitOptions, true];
 
 // Begin gear assignement depending on unit's role.
 _unit setVariable ["bmt_var_configEquipment_Ready", false, true];
@@ -112,75 +111,75 @@ switch (_unitFaction) do {
     //====================================================================================================//
 
     // Equipment for BLUFOR faction.
-    case "blu_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
+    case "blu_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
 
     // Equipment for CTRG faction (APEX).
-    case "blu_ctrg_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
+    case "blu_ctrg_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
 
     // Equipment for GENDARMERIE faction (APEX).
-    case "blu_gen_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
+    case "blu_gen_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
 
     // Equipment for BLUFOR Pacific faction (APEX).
-    case "blu_t_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
+    case "blu_t_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_blu_f; };
 
     // Equipment for FIA faction.
-    case "blu_g_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
+    case "blu_g_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
 
     // Equipment for FIA faction.
-    case "ind_g_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
+    case "ind_g_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
 
     // Equipment for FIA faction.
-    case "opf_g_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
+    case "opf_g_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_fia_f; };
 
     // Equipment for OPFOR faction.
-    case "opf_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_opf_f; };
+    case "opf_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_opf_f; };
 
     // Equipment for OPFOR Pacific faction (APEX).
-    case "opf_t_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_opf_f; };
+    case "opf_t_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_opf_f; };
 
     // Equipment for Independent faction.
-    case "ind_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_ind_f; };
+    case "ind_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_ind_f; };
 
     // Equipment for Syndikat faction.
-    case "ind_c_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_ind_f; };
+    case "ind_c_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_ind_f; };
 
     // Equipment for Civilian faction.
-    case "civ_f": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_civ_f; };
+    case "civ_f": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_civ_f; };
 
     //====================================================================================================//
     // RHS factions.                                                                                      //
     //====================================================================================================//
 
     // Equipment for RHS: USAF "United States Army" (OCP) faction.
-    case "rhs_faction_usarmy_d": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
+    case "rhs_faction_usarmy_d": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
 
     // Equipment for RHS: USAF "United States Army" (UCP) faction.
-    case "rhs_faction_usarmy_wd": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
+    case "rhs_faction_usarmy_wd": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
 
     // Equipment for RHS: USAF "United States Marine Corps" (D) faction.
-    case "rhs_faction_usmc_d": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
+    case "rhs_faction_usmc_d": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
 
     // Equipment for RHS: USAF "United States Marine Corps" (WD) faction.
-    case "rhs_faction_usmc_wd": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
+    case "rhs_faction_usmc_wd": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
 
     // Equipment for RHS: USAF "United States Navy" faction.
-    case "rhs_faction_usn": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
+    case "rhs_faction_usn": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_usaf; };
 
     // Equipment for RHS: Insurgents faction.
-    case "rhs_faction_insurgents": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_insurgents; };
+    case "rhs_faction_insurgents": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_insurgents; };
 
     // Equipment for RHS: AFRF "Russian Airborne Troops" faction.
-    case "rhs_faction_vdv": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_vdv; };
+    case "rhs_faction_vdv": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_vdv; };
 
     // Equipment for RHS: AFRF "Soviet Air Defense Forces" faction.
-    case "rhs_faction_vpvo": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_vpvo; };
+    case "rhs_faction_vpvo": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_rhs_vpvo; };
 
     //====================================================================================================//
     // Bundeswehr.                                                                                        //
     //====================================================================================================//
 
     // Equipment for German army "Bundeswehr" faction.
-    case "bwa3_faction": { [_unitRole, _unit, _unitFaction] call bmt_fnc_configEquipment_bwa3_faction; };
+    case "bwa3_faction": { [_unitOptions, _unit, _unitFaction] call bmt_fnc_configEquipment_bwa3_faction; };
 
     default { _recognised = false; };
 };

--- a/src/configEquipment/scripts/bmt_configEquipment_VAprofiles.sqf
+++ b/src/configEquipment/scripts/bmt_configEquipment_VAprofiles.sqf
@@ -34,13 +34,22 @@
 // Changes: 1.0 (2015/11/26) First public version.                                                       //
 //=======================================================================================================//
 
-private["_unit", "_unitRole", "_loadout", "_VAProfile", "_recognised"];
+private["_unit", "_unitOptions", "_unitRole", "_loadout", "_VAProfile", "_recognised"];
 
 // Only execute if unit is local.
 if !(local player) exitWith {};
 
 _unit = player;
-_unitRole = _unit getVariable ["bmt_var_configEquipment", "NIL"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "NIL"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
+
+_unitRole = toLower _unitRole;
+
 _recognised = true;
 
 // Configure equipment for each unit.

--- a/src/respawn/scripts/bmt_respawn_onPlayerRespawn.sqf
+++ b/src/respawn/scripts/bmt_respawn_onPlayerRespawn.sqf
@@ -11,7 +11,7 @@
 
 // Parameters passed when onPlayerRespawn.
 params [["_unit",objNull], ["_oldUnit",objNull], ["_respawn",0], ["_respawnDelay",0]];
-private ["_unitRole"];
+private ["_unitOptions"];
 
 // End the mission if there are no alive units and respawn of type "NONE" or "BIRD".
 if (_respawn <= 1) then {
@@ -38,8 +38,8 @@ if (_respawn == 1) then {
     if (bmt_param_respawn_saveGear == 1) then {
         _unit setUnitLoadout(_unit getVariable["bmt_array_savedLoadout",[]]);
     } else {
-        _unitRole = _unit getVariable "bmt_var_configEquipment";
-        [_unitRole, _unit] call bmt_fnc_configEquipment;
+        _unitOptions = _unit getVariable "bmt_var_configEquipment";
+        [_unitOptions, _unit] call bmt_fnc_configEquipment;
     };
 
     [] call bmt_fnc_respawn_moveToMarker;

--- a/src/tfar/functions/fn_tfar_addRadios.sqf
+++ b/src/tfar/functions/fn_tfar_addRadios.sqf
@@ -13,9 +13,15 @@
 
 // Variable declarations.
 params [["_unit", objNull]];
-private["_unitRole", "_longRangeRadio", "_shortRangeRadio", "_riflemanRadio", "_objectsBackpack"];
+private["_unitOptions", "_unitRole", "_longRangeRadio", "_shortRangeRadio", "_riflemanRadio", "_objectsBackpack"];
 
-_unitRole = _unit getVariable ["bmt_var_configEquipment", "nil"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "nil"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 // Assign radios depending on unit's side.
 switch ((side _unit)) do {

--- a/src/tfar/functions/fn_tfar_configureChannels.sqf
+++ b/src/tfar/functions/fn_tfar_configureChannels.sqf
@@ -13,10 +13,16 @@
 
 // Variable declarations.
 params [["_unit", objNull]];
-private["_unitGroup", "_unitRole", "_frequencies", "_channel", "_squadChannel", "_fireteamChannel", "_commandChannel"];
+private["_unitGroup", "_unitOptions", "_unitRole", "_frequencies", "_channel", "_squadChannel", "_fireteamChannel", "_commandChannel"];
 
 _unitGroup = _unit getVariable ["bmt_var_unitGroup", ["nil", -1]];
-_unitRole = _unit getVariable ["bmt_var_configEquipment", "nil"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "nil"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 if ((_unitGroup select 0 != "nil") and (_unitGroup select 1 != -1)) then {
 

--- a/src/tfar/functions/fn_tfar_configureStereo.sqf
+++ b/src/tfar/functions/fn_tfar_configureStereo.sqf
@@ -18,8 +18,15 @@
 
 // Variable declarations.
 params [["_unit", objNull]];
+private ["_unitOptions", "_unitRole"];
 
-private _unitRole = _unit getVariable ["bmt_var_configEquipment", "nil"];
+_unitOptions = _unit getVariable ["bmt_var_configEquipment", "nil"];
+
+if ((typeName _unitOptions) == "STRING") then {
+    _unitRole = _unitOptions;
+} else {
+    _unitRole = _unitOptions select 0; // First entry must always be the unit role
+};
 
 if (_unitRole != "nil") then {
 


### PR DESCRIPTION
Add  additional options to configure the loadout in bmt_fnc_configEquipment. The first parameter can either be a string (for backwards compatibility) or an array, in which the first element is ALWAYS  the unit role and the other elements are additional options.

For a squad leader:
["sl", this] call bmt_fnc_configEquipment.
[["sl", "desert"], this] call bmt_fnc_configEquipment.

The modifications are compatible with bmt_configUnit, TFAR, ACRE 2 and respawn functions.